### PR TITLE
DCPUToolchain compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,6 +127,11 @@ Thumbs.db
 Desktop.ini
 
 
+# Vim and backup files #
+########################
+*.swp
+*~
+
 #############
 ## Python
 #############

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ https://github.com/orlof/dcpu-admiral
 
 To build from source, run the following with the DCPU Toolchain (DCPUTeam/DCPUToolchain)
 
-    dtasm admiral.dasm16 -o admiral.bin
+    dtasm --binary admiral.dasm16 -o admiral.bin
     
 or this with Organic (SirCmpwn/Organic) (you have to use long literals at the moment, as Organic is very slow at optimising at the moment)
 

--- a/admiral.dasm16
+++ b/admiral.dasm16
@@ -2,6 +2,7 @@
 #include "interpreter.dasm16"
 #include "data.dasm16"
 #include "parser.dasm16"
+#include "float.dasm16"
 #include "lexer2.dasm16"
 #include "stdlib.dasm16"
 #include "memory.dasm16"
@@ -11,4 +12,3 @@
 #include "string2.dasm16"
 #include "edit.dasm16"
 #include "screen.dasm16"
-#include "float.dasm16"


### PR DESCRIPTION
I fixed a bug in the toolchain pre-processor, so that it can assemble admiral and noticed a few problems in admiral, and fixed those.

mostly:
1.
# define

have to be defined before used (in this case for the floats)

2.
updated readme for the correct assemble command of the toolchain

Cheers!

Btw.: admiral is really awesome, huge props ;)
