### PR TITLE
#define cannot be followed by comment

### DIFF
--- a/defs.dasm16
+++ b/defs.dasm16
@@ -5,7 +5,8 @@
 #define FALSE           0
 
 #define HEAP_GC_TRIGGER 10
-#define FLOAT_PRECISION	2	; 2*16=32 bits for mantissa
+#define FLOAT_PRECISION	2
+; 2*16=32 bits for mantissa
 
 #define FONT_COLOR      0x7000
 #define SCREEN_COLS     32


### PR DESCRIPTION
Moved comment after #define FLOAT_PRECISION to line below
